### PR TITLE
매장찾기 & 지도 기능 업데이트

### DIFF
--- a/Toosome/src/main/webapp/WEB-INF/views/index.jsp
+++ b/Toosome/src/main/webapp/WEB-INF/views/index.jsp
@@ -271,7 +271,7 @@
                 id="search"
                 placeholder="매장명 또는 주소를 입력해 주세요."
               />
-              <input type="submit" value="" />
+              <input id="search-button" type="submit" value="" />
             </fieldset>
           </form>
         </div>

--- a/Toosome/src/main/webapp/resources/css/subpages/map/map.css
+++ b/Toosome/src/main/webapp/resources/css/subpages/map/map.css
@@ -41,6 +41,10 @@
   z-index: 1;
   font-size: 1rem;
   border-radius: 10px;
+  -ms-overflow-style: none;
+}
+#menu_wrap::-webkit-scrollbar{
+  display:none; 
 }
 .bg_white {
   background: #fff;
@@ -110,18 +114,21 @@
 #placesList .item span {
   display: block;
   margin-top: 4px;
+  font-size: 0.875rem;
 }
 #placesList .item h5,
 #placesList .item .info {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  font-size: 1rem;
 }
 #placesList .item .info {
   padding: 10px 0 10px 55px;
 }
 #placesList .info .gray {
   color: #8a8a8a;
+  font-size: 0.875rem;
 }
 #placesList .info .jibun {
   padding-left: 26px;
@@ -130,6 +137,7 @@
 }
 #placesList .info .tel {
   color: #009900;
+  font-size: 0.8125rem;
 }
 #placesList .item .markerbg {
   float: left;

--- a/Toosome/src/main/webapp/resources/js/main/script.js
+++ b/Toosome/src/main/webapp/resources/js/main/script.js
@@ -143,4 +143,16 @@ $(function () {
   window.addEventListener('scroll', debounce(checkSlide));
 
   // section image slide end------------------------------------------------------------
+  
+  // sesarch store start ---------------------------------------------------------------
+  const inputValue = document.querySelector('#search');
+  const searchBtn = document.querySelector('#search-button');
+
+  const searchBtnHandler = () => {
+	let value = inputValue.value;
+	location.href = `/map?address=${encodeURIComponent(value)}`;
+  };
+
+  searchBtn.addEventListener('click', searchBtnHandler);
+
 });

--- a/Toosome/src/main/webapp/resources/js/subpages/map/map.js
+++ b/Toosome/src/main/webapp/resources/js/subpages/map/map.js
@@ -187,6 +187,7 @@ const getListItem = (index, places) => {
 		if(status === kakao.maps.services.Status.OK) {
 			const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
 			map.setCenter(coords);
+			keyword.value = `${places.road_address_name}`;
 		};
 	});
   });
@@ -200,7 +201,7 @@ let markers = [];
 const addMarker = (position, idx) => {
   // 마커 이미지
   const imageSrc =
-    'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png';
+    '/resources/img/subpages/map/marker.png';
   const imageSize = new kakao.maps.Size(36, 37);
   const imageOptions = {
     spriteSize: new kakao.maps.Size(36, 691),
@@ -279,7 +280,12 @@ const displayPagnition = (pagination) => {
 
 // 검색결과 목록, 마커 click event
 const displayInfoWindow = (marker, title) => {
-  let content = `<div style="padding:5px;z-index:1;">${title}</div>`;
+  let content = `
+	<div style="width:auto;height:auto;background:rgba(214, 92, 92, 0.3);padding:10px;z-index:1;text-align:center;border:none;">
+		<img src="/resources/img/logo.png">
+		<p style="font-size:1rem;font-weight:bold;background-color:white;border-radius:5px;margin-top:10px;padding:4px;">${title}</p>
+	</div>
+  `;
 
   infoWindow.setContent(content);
   infoWindow.open(map, marker);


### PR DESCRIPTION
1. 지도 목록 및 마커 CSS style 변경
2. index.jsp의 매장찾기 검색 구현
  - index.jsp에서 검색어 입력 후 매장찾기 검색을 누릅니다.
  - parameter를 물고 map 페이지로 넘어갑니다.
  - parameter의 keyword로 검색 후 검색 결과를 표시합니다.
 
** * index의 매장찾기로 넘어온 경우와 gnb의 store를 눌러서 넘어온 경우를 분기 **
분기를 나누는 변수와 메소드는 다음과 같습니다
![image](https://user-images.githubusercontent.com/69956570/113080235-88135600-9211-11eb-9226-3ad59cde9590.png)

분기를 기점으로 window.onload시 실행되는 로직이 분리됩니다.