### PR TITLE
공지사항, 뉴스, QnA 페이지 게시판 정렬기능 추가

### DIFF
--- a/Toosome/src/main/webapp/WEB-INF/views/subpages/news/news.jsp
+++ b/Toosome/src/main/webapp/WEB-INF/views/subpages/news/news.jsp
@@ -26,6 +26,11 @@
         	</div>
 			<p>TOOSOME PLACE의 뉴스를 확인하세요</p>
         	<div class="search-container">
+        		<select class="search-select" onchange="selectHandler(this);">
+        			<option value="0">번호순</option>
+        			<option value="1">작성일순</option>
+        			<option value="2">조회수순</option>
+        		</select>
         		<div class="search-wrapper">
         			<input id="search-input" type="search" placeholder="검색어를 입력하세요">
         			<button id="search-btn">검색</button>

--- a/Toosome/src/main/webapp/WEB-INF/views/subpages/notice/notice.jsp
+++ b/Toosome/src/main/webapp/WEB-INF/views/subpages/notice/notice.jsp
@@ -26,6 +26,11 @@
         	</div>
 			<p>TOOSOME PLACE의 공지사항을 확인하세요</p>
         	<div class="search-container">
+        		<select class="search-select" onchange="selectHandler(this);">
+        			<option value="0">번호순</option>
+        			<option value="1">작성일순</option>
+        			<option value="2">조회수순</option>
+        		</select>
         		<div class="search-wrapper">
         			<input id="search-input" type="search" placeholder="검색어를 입력하세요">
         			<button id="search-btn">검색</button>        			

--- a/Toosome/src/main/webapp/WEB-INF/views/subpages/qna/qna.jsp
+++ b/Toosome/src/main/webapp/WEB-INF/views/subpages/qna/qna.jsp
@@ -34,6 +34,11 @@
         	</div>
 			<p>고객 한 분 한 분의 의견에 귀 기울이는 투썸플레이스가 되겠습니다</p>
         	<div class="search-container">
+        		<select class="search-select" onchange="selectHandler(this);">
+        			<option value="0">번호순</option>
+        			<option value="1">작성일순</option>
+        			<option value="2">조회수순</option>
+        		</select>
         		<div class="search-wrapper">
         			<input id="search-input" type="search" placeholder="검색어를 입력하세요">
         			<button id="search-btn">검색</button>

--- a/Toosome/src/main/webapp/resources/css/subpages/news/news.css
+++ b/Toosome/src/main/webapp/resources/css/subpages/news/news.css
@@ -67,7 +67,21 @@ section > p {
 	background: rgba(102,102,102,0.3);
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
+}
+
+.search-select {
+	outline: none;
+	padding: 0 10px;
+	border: none;
+	margin-left: 15px;
+	width: 120px;
+	height: 40px;
+	border-radius: 5px;
+	border: 1px solid #eee;
+	cursor: pointer;
+	font-family: 'Noto Sans KR', sans-serif;
+	font-size: 1rem;
 }
 
 .search-wrapper {
@@ -86,6 +100,8 @@ section > p {
 	border: 1px solid #eee;
 	margin-right: 0.9375rem;
 	padding-left: 5px;
+	font-family: 'Noto Sans KR', sans-serif;
+	font-size: 1rem;
 }
 
 .search-wrapper > button {

--- a/Toosome/src/main/webapp/resources/css/subpages/notice/notice.css
+++ b/Toosome/src/main/webapp/resources/css/subpages/notice/notice.css
@@ -67,7 +67,21 @@ section > p {
 	background: rgba(102,102,102,0.3);
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
+}
+
+.search-select {
+	outline: none;
+	padding: 0 10px;
+	border: none;
+	margin-left: 15px;
+	width: 120px;
+	height: 40px;
+	border-radius: 5px;
+	border: 1px solid #eee;
+	cursor: pointer;
+	font-family: 'Noto Sans KR', sans-serif;
+	font-size: 1rem;
 }
 
 .search-wrapper {
@@ -86,6 +100,8 @@ section > p {
 	border: 1px solid #eee;
 	margin-right: 0.9375rem;
 	padding-left: 5px;
+	font-family: 'Noto Sans KR', sans-serif;
+	font-size: 1rem;
 }
 
 .search-wrapper > button {

--- a/Toosome/src/main/webapp/resources/css/subpages/qna/qna.css
+++ b/Toosome/src/main/webapp/resources/css/subpages/qna/qna.css
@@ -67,7 +67,21 @@ section > p {
 	background: rgba(102,102,102,0.3);
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
+}
+
+.search-select {
+	outline: none;
+	padding: 0 10px;
+	border: none;
+	margin-left: 15px;
+	width: 120px;
+	height: 40px;
+	border-radius: 5px;
+	border: 1px solid #eee;
+	cursor: pointer;
+	font-family: 'Noto Sans KR', sans-serif;
+	font-size: 1rem;
 }
 
 .search-wrapper {
@@ -86,6 +100,8 @@ section > p {
 	border: 1px solid #eee;
 	margin-right: 0.9375rem;
 	padding-left: 5px;
+	font-family: 'Noto Sans KR', sans-serif;
+	font-size: 1rem;
 }
 
 .search-wrapper > button {

--- a/Toosome/src/main/webapp/resources/js/subpages/news/news.js
+++ b/Toosome/src/main/webapp/resources/js/subpages/news/news.js
@@ -3,6 +3,7 @@ const newsBoard = document.getElementById('news');
 const searchBtn = document.getElementById('search-btn'); // 검색 버튼
 const searchInput = document.getElementById('search-input'); // 검색 인풋창
 
+let result = []; // AJAX 결과 복사할 빈 배열
 let currentPage = 1; // 현재 페이지
 let rows = 10; // 한 페이지에 보여줄 게시글 수
 let url = ''; // URL
@@ -93,13 +94,48 @@ const btnHandler = (e,items,page) => {
 	e.target.classList.add('active');
 };
 
+// 정렬 select 핸들러
+const selectHandler = (select) => {
+	// selected value
+	let value = select.options[select.selectedIndex].value;
+	
+	// init
+	currentPage = 1;
+	rows = 10;
+	let temp = [...result]; // 배열 복사
+	let newRes = []; // 정렬된 배열을 담을 빈 배열
+	
+	switch(value) {
+		case '0': 
+			displayList(temp, newsBoard, rows, currentPage);
+			setPagination(temp, pagination, rows);
+			break;
+		case '1': // 작성일순 정렬 
+			newRes = temp.sort((a,b) => {
+				a = new Date(a.newsBoardRegdate);
+				b = new Date(b.newsBoardRegdate);
+				return b - a;
+			});
+			displayList(newRes, newsBoard, rows, currentPage);
+			setPagination(newRes, pagination, rows);
+			break;
+		case '2': // 조회수순 정렬
+			newRes = temp.sort((a,b) => {
+				return b.newsBoardViewCount - a.newsBoardViewCount;
+			});
+			displayList(newRes, newsBoard, rows, currentPage);
+			setPagination(newRes, pagination, rows);
+			break;
+	};
+};
+
 // AJAX 요청 함수
 const getPage = (url) => {
 	$.ajax({
 		url,
 		success: (res) => {
-			const newRes = res.reverse();
-			
+			result = [...res];
+			const newRes = result.reverse();
 			displayList(newRes, newsBoard, rows, currentPage);
 			setPagination(newRes, pagination, rows);			
 		}

--- a/Toosome/src/main/webapp/resources/js/subpages/notice/notice.js
+++ b/Toosome/src/main/webapp/resources/js/subpages/notice/notice.js
@@ -3,6 +3,7 @@ const noticeBoard = document.getElementById('notice'); // 게시판
 const searchBtn = document.getElementById('search-btn'); // 검색 버튼
 const searchInput = document.getElementById('search-input'); // 검색 인풋창
 
+let result = []; // AJAX 결과 복사할 빈 배열
 let currentPage = 1; // 현재 페이지
 let rows = 10; // 한 페이지에 보여줄 게시글 수
 let url = ''; // URL
@@ -94,7 +95,8 @@ const getPage = (url) => {
 	$.ajax({
 		url,
 		success: (res) => {
-			const newRes = res.reverse();
+			result = [...res];
+			const newRes = result.reverse();
 			
 			displayList(newRes, noticeBoard, rows, currentPage);
 			setPagination(newRes, pagination, rows);			
@@ -122,6 +124,41 @@ searchInput.addEventListener('keypress', (e) => {
       searchHandler();
     }
 });
+
+// 정렬 select 핸들러
+const selectHandler = (select) => {
+	// selected value
+	let value = select.options[select.selectedIndex].value;
+	
+	// init
+	currentPage = 1;
+	rows = 10;
+	let temp = [...result]; // 배열 복사
+	let newRes = []; // 정렬된 배열을 담을 빈 배열
+	
+	switch(value) {
+		case '0': 
+			displayList(temp, noticeBoard, rows, currentPage);
+			setPagination(temp, pagination, rows);
+			break;
+		case '1': // 작성일순 정렬 
+			newRes = temp.sort((a,b) => {
+				a = new Date(a.noticeBoardRegdate);
+				b = new Date(b.noticeBoardRegdate);
+				return b - a;
+			});
+			displayList(newRes, noticeBoard, rows, currentPage);
+			setPagination(newRes, pagination, rows);
+			break;
+		case '2': // 조회수순 정렬
+			newRes = temp.sort((a,b) => {
+				return b.noticeBoardViewCount - a.noticeBoardViewCount;
+			});
+			displayList(newRes, noticeBoard, rows, currentPage);
+			setPagination(newRes, pagination, rows);
+			break;
+	};
+};
 
 // onload시 AJAX 요청
 $(document).ready(() => {

--- a/Toosome/src/main/webapp/resources/js/subpages/qna/qna.js
+++ b/Toosome/src/main/webapp/resources/js/subpages/qna/qna.js
@@ -3,10 +3,12 @@ const qnaBoard = document.getElementById('qna');
 const searchBtn = document.getElementById('search-btn'); // 검색 버튼
 const searchInput = document.getElementById('search-input'); // 검색 인풋창
 
+let result = []; // AJAX 결과 복사할 빈 배열
 let currentPage = 1; // 현재 페이지
 let rows = 10; // 한 페이지에 보여줄 게시글 수
 let csrfTokenValue = $("meta[name='_csrf']").attr("content");
 let csrfHeaderName = $("meta[name='_csrf_header']").attr("content");
+
 // 게시판 상세 페이지로 이동 함수
 const locateQnaDetail = (index, isLocked) => {
 	let pwd = '';
@@ -139,7 +141,8 @@ const getPage = (url) => {
 	$.ajax({
 		url,
 		success: (res) => {
-			const newRes = res.reverse();
+			result = [...res];
+			const newRes = result.reverse();
 			
 			displayList(newRes, qnaBoard, rows, currentPage);
 			setPagination(newRes, pagination, rows);			
@@ -170,6 +173,41 @@ searchInput.addEventListener('keypress', (e) => {
       searchHandler();
     }
 });
+
+// 정렬 select 핸들러
+const selectHandler = (select) => {
+	// selected value
+	let value = select.options[select.selectedIndex].value;
+	
+	// init
+	currentPage = 1;
+	rows = 10;
+	let temp = [...result]; // 배열 복사
+	let newRes = []; // 정렬된 배열을 담을 빈 배열
+	
+	switch(value) {
+		case '0': 
+			displayList(temp, qnaBoard, rows, currentPage);
+			setPagination(temp, pagination, rows);
+			break;
+		case '1': // 작성일순 정렬 
+			newRes = temp.sort((a,b) => {
+				a = new Date(a.qnaBoardRegdate);
+				b = new Date(b.qnaBoardRegdate);
+				return b - a;
+			});
+			displayList(newRes, qnaBoard, rows, currentPage);
+			setPagination(newRes, pagination, rows);
+			break;
+		case '2': // 조회수순 정렬
+			newRes = temp.sort((a,b) => {
+				return b.qnaBoardViewCount - a.qnaBoardViewCount;
+			});
+			displayList(newRes, qnaBoard, rows, currentPage);
+			setPagination(newRes, pagination, rows);
+			break;
+	};
+};
 
 // onload시 AJAX 요청
 $(document).ready(() => {


### PR DESCRIPTION
번호순, 작성일순, 조회수순 정렬 기능 추가

* 번호순 정렬은 default 이기 때문에 초기 AJAX 요청시 reverse한 데이터를 그대로 사용합니다.
* 작성일순 정렬
![image](https://user-images.githubusercontent.com/69956570/115586889-02faf880-a308-11eb-8038-47d32fb8bc4b.png)

* 조회수순 정렬
![image](https://user-images.githubusercontent.com/69956570/115586929-0c846080-a308-11eb-90b3-5b7bf97c3557.png)
